### PR TITLE
add multiple market subscription method

### DIFF
--- a/examples/ws/book/main.go
+++ b/examples/ws/book/main.go
@@ -12,12 +12,27 @@ func main() {
 		log.Fatal(err)
 	}
 
-	bookchn, err := ws.Book().Subscribe("ETH-EUR")
-	if err != nil {
-		log.Fatal(err)
-	}
+	go func() {
+		bookchn, err := ws.Book().Subscribe("ETH-EUR")
+		if err != nil {
+			log.Fatal(err)
+		}
 
-	for bookEvent := range bookchn {
-		log.Println(bookEvent)
-	}
+		for bookEvent := range bookchn {
+			log.Println(bookEvent)
+		}
+	}()
+
+	go func() {
+		bookchn, err := ws.Book().SubscribeToMarkets([]string{"ETH-EUR", "BTC-EUR"})
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		for bookEvent := range bookchn {
+			log.Println(bookEvent)
+		}
+	}()
+
+	select {}
 }

--- a/wsc/trades.go
+++ b/wsc/trades.go
@@ -69,6 +69,25 @@ func (t *tradesEventHandler) Subscribe(market string, buffSize ...uint64) (<-cha
 	return chn, nil
 }
 
+func (t *tradesEventHandler) SubscribeToMarkets(markets []string, buffSize ...uint64) (<-chan TradesEvent, error) {
+	for _, market := range markets {
+		if t.subs.Has(market) {
+			return nil, newErrSubscriptionAlreadyActive(market)
+		}
+	}
+
+	t.writechn <- newWebSocketMessage(actionSubscribe, channelNameTrades, markets...)
+
+	size := util.IfOrElse(len(buffSize) > 0, func() uint64 { return buffSize[0] }, DefaultBuffSize)
+
+	chn := make(chan TradesEvent, size)
+	for _, market := range markets {
+		t.subs.Set(market, chn)
+	}
+
+	return chn, nil
+}
+
 func (t *tradesEventHandler) Unsubscribe(market string) error {
 	sub, exist := t.subs.Get(market)
 

--- a/wsc/wsclient.go
+++ b/wsc/wsclient.go
@@ -2,6 +2,7 @@ package wsc
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -34,6 +35,8 @@ type EventHandler[T any] interface {
 	//
 	// Default buffSize: 50
 	Subscribe(market string, buffSize ...uint64) (<-chan T, error)
+
+	SubscribeToMarkets(markets []string, buffSize ...uint64) (<-chan T, error)
 
 	// Unsubscribe from market.
 	Unsubscribe(market string) error
@@ -293,13 +296,13 @@ func (ws *wsClient) reconnect() {
 	}
 }
 
-func newWebSocketMessage(action Action, channelName ChannelName, market string) WebSocketMessage {
+func newWebSocketMessage(action Action, channelName ChannelName, market ...string) WebSocketMessage {
 	return WebSocketMessage{
 		Action: action.Value,
 		Channels: []Channel{
 			{
 				Name:    channelName.Value,
-				Markets: []string{market},
+				Markets: market,
 			},
 		},
 	}
@@ -476,4 +479,8 @@ func (ws *wsClient) logDebug(message string, args ...any) {
 	if ws.debug {
 		log.Logger().Debug(message, args...)
 	}
+}
+
+func newErrSubscriptionAlreadyActive(market string) error {
+	return fmt.Errorf("subscription already active for market %s", market)
 }


### PR DESCRIPTION
If you need to subscribe to a lot of markets, it is easy to consume rate limiting while subscribing the markets one by one. Bitvavo supports subscribing to multiple markets. 

In this pr, a new method(_SubscribeToMarkets_) added to _EventHandler_ interface for subscribing multiple markets and implemented in all  _EventHandler_ types.